### PR TITLE
ci: Add `pytest-xdist` to `--group tests`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ tests = [
   "pydantic-extra-types[pycountry,phonenumbers]",
   "pytest>=8.0.0",
   "pytest-cov>=6.0.0",
+  "pytest-xdist>=3.8.0",
 ]
 
 typing = [


### PR DESCRIPTION
## Description

I *could* disable my environment variable that expected `pytest-xdist` to be installed - but it can give a very nice perf boost

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧪 Test improvement
- [ ] 🔧 Maintenance/Refactoring
- [ ] ⚡ Performance improvement
- [x] 🏗️ Build/CI improvement

## Related Issues

<!-- Link related issues using #issue_number or "Closes #issue_number" -->

- Closes #
- Related to #

## Changes Made

<!-- Please describe the main changes made in this PR -->

## Checklist

<!-- Ensure all items are checked before requesting review -->

- [ ] My code follows the project's style guidelines (ruff)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
